### PR TITLE
Add tostring to Element classes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ Declare a dependency on the `siren-core` JAR in your build tool:
 [source,groovy]
 ----
 dependencies {
-    compile 'org.unbrokendome.siren:siren-core:0.2.0'
+    compile 'org.unbroken-dome.siren:siren-core:0.2.0'
 }
 ----
 
@@ -45,7 +45,7 @@ dependencies {
 ----
 <dependencies>
     <dependency>
-        <groupId>org.unbrokendome.siren</groupId>
+        <groupId>org.unbroken-dome.siren</groupId>
         <artifactId>siren-core</artifactId>
         <version>0.2.0</version>
     </dependency>
@@ -162,8 +162,8 @@ plugins {
 }
 
 dependencies {
-    implementation 'org.unbrokendome.siren:siren-core:0.2.0'
-    apt 'org.unbrokendome.siren:siren-spring-ap:0.2.0'
+    implementation 'org.unbroken-dome.siren:siren-core:0.2.0'
+    apt 'org.unbroken-dome.siren:siren-spring-ap:0.2.0'
 }
 ----
 
@@ -236,7 +236,7 @@ plugins {
 }
 
 dependencies {
-    compile 'org.unbrokendome.siren:siren-core:0.2.0'
-    kapt 'org.unbrokendome.siren:siren-spring-ap:0.2.0'
+    compile 'org.unbroken-dome.siren:siren-core:0.2.0'
+    kapt 'org.unbroken-dome.siren:siren-spring-ap:0.2.0'
 }
 ----

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/Action.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/Action.java
@@ -70,4 +70,18 @@ public final class Action extends Reference {
     public int hashCode() {
         return Objects.hash(super.hashCode(), name, method, fields);
     }
+
+    @Override
+    public String toString() {
+        return "Action{" +
+                "name='" + name + '\'' +
+                ", method='" + method + '\'' +
+                ", fields=" + fields +
+                ", href='" + getHref() + '\'' +
+                ", type='" + getType() + '\'' +
+                ", classes=" + getClasses() +
+                ", title='" + getTitle() + '\'' +
+                ", customProperties=" + getCustomProperties() +
+                '}';
+    }
 }

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/ActionField.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/ActionField.java
@@ -115,4 +115,16 @@ public final class ActionField extends Element {
     public int hashCode() {
         return Objects.hash(super.hashCode(), name, type, value);
     }
+
+    @Override
+    public String toString() {
+        return "ActionField{" +
+                "name='" + name + '\'' +
+                ", type=" + type +
+                ", value=" + value +
+                ", classes=" + getClasses() +
+                ", title='" + getTitle() + '\'' +
+                ", customProperties=" + getCustomProperties() +
+                '}';
+    }
 }

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/Element.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/Element.java
@@ -65,4 +65,13 @@ public abstract class Element implements Serializable {
     public int hashCode() {
         return Objects.hash(classes, title);
     }
+
+    @Override
+    public String toString() {
+        return "Element{" +
+                "classes=" + classes +
+                ", title='" + title + '\'' +
+                ", customProperties=" + customProperties +
+                '}';
+    }
 }

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/EmbeddedEntity.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/EmbeddedEntity.java
@@ -49,4 +49,18 @@ public final class EmbeddedEntity extends FullEntity {
     public int hashCode() {
         return Objects.hash(super.hashCode(), rel);
     }
+
+    @Override
+    public String toString() {
+        return "EmbeddedEntity{" +
+                "rel=" + rel +
+                ", properties=" + getProperties() +
+                ", entities=" + getEntities() +
+                ", links=" + getLinks() +
+                ", actions=" + getActions() +
+                ", classes=" + getClasses() +
+                ", title='" + getTitle() + '\'' +
+                ", customProperties=" + getCustomProperties() +
+                '}';
+    }
 }

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/FullEntity.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/FullEntity.java
@@ -84,4 +84,17 @@ public abstract class FullEntity extends Entity {
         return Objects.hash(super.hashCode(),
                 properties, entities, links, actions);
     }
+
+    @Override
+    public String toString() {
+        return "FullEntity{" +
+                "properties=" + properties +
+                ", entities=" + entities +
+                ", links=" + links +
+                ", actions=" + actions +
+                ", classes=" + getClasses() +
+                ", title='" + getTitle() + '\'' +
+                ", customProperties=" + getCustomProperties() +
+                '}';
+    }
 }

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/Link.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/Link.java
@@ -49,4 +49,16 @@ public final class Link extends Reference {
     public int hashCode() {
         return Objects.hash(super.hashCode(), rel);
     }
+
+    @Override
+    public String toString() {
+        return "Link{" +
+                "rel=" + rel +
+                ", href='" + getHref() + '\'' +
+                ", type='" + getType() + '\'' +
+                ", classes=" + getClasses() +
+                ", title='" + getTitle() + '\'' +
+                ", customProperties=" + getCustomProperties() +
+                '}';
+    }
 }

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/Reference.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/Reference.java
@@ -58,4 +58,15 @@ public abstract class Reference extends Element {
     public int hashCode() {
         return Objects.hash(super.hashCode(), href, type);
     }
+
+    @Override
+    public String toString() {
+        return "Reference{" +
+                "href='" + href + '\'' +
+                ", type='" + type + '\'' +
+                ", classes=" + getClasses() +
+                ", title='" + getTitle() + '\'' +
+                ", customProperties=" + getCustomProperties() +
+                '}';
+    }
 }

--- a/siren-core/src/main/java/org/unbrokendome/siren/model/RootEntity.java
+++ b/siren-core/src/main/java/org/unbrokendome/siren/model/RootEntity.java
@@ -23,4 +23,17 @@ public final class RootEntity extends FullEntity {
     public static RootEntityBuilder builder() {
         return new RootEntityBuilder();
     }
+
+    @Override
+    public String toString() {
+        return "RootEntity{" +
+                "properties=" + getProperties() +
+                ", entities=" + getEntities() +
+                ", links=" + getLinks() +
+                ", actions=" + getActions() +
+                ", classes=" + getClasses() +
+                ", title='" + getTitle() + '\'' +
+                ", customProperties=" + getCustomProperties() +
+                '}';
+    }
 }


### PR DESCRIPTION
This adds toString to Element classes to make testing and logging easier to read, for example, API test with Hamcrest matchers where the toString is used.

The README is also updated to reflect the dependency that is published to JCenter.